### PR TITLE
[#2]feat：Backlog APIクライアント基盤を実装

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,1 +1,100 @@
 package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Client is the Backlog API client.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewClient creates a new Backlog API client.
+func NewClient(spaceURL, apiKey string) *Client {
+	base := strings.TrimRight(spaceURL, "/") + "/api/v2"
+	return &Client{
+		baseURL:    base,
+		apiKey:     apiKey,
+		httpClient: &http.Client{},
+	}
+}
+
+func (c *Client) do(method, path string, params url.Values, body io.Reader) (*http.Response, error) {
+	u := c.baseURL + path
+
+	if params == nil {
+		params = url.Values{}
+	}
+	params.Set("apiKey", c.apiKey)
+
+	var req *http.Request
+	var err error
+
+	switch method {
+	case http.MethodGet:
+		u += "?" + params.Encode()
+		req, err = http.NewRequest(method, u, nil)
+	case http.MethodPost, http.MethodPatch:
+		req, err = http.NewRequest(method, u+"?apiKey="+url.QueryEscape(c.apiKey), strings.NewReader(params.Encode()))
+		if err == nil {
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		}
+	default:
+		return nil, fmt.Errorf("サポートされていないHTTPメソッドです: %s", method)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("リクエストの作成に失敗しました: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("リクエストの送信に失敗しました: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		respBody, _ := io.ReadAll(resp.Body)
+
+		var errResp BacklogErrorResponse
+		if json.Unmarshal(respBody, &errResp) == nil && len(errResp.Errors) > 0 {
+			return nil, fmt.Errorf("Backlog API エラー: %s (code: %d)", errResp.Errors[0].Message, errResp.Errors[0].Code)
+		}
+		return nil, fmt.Errorf("Backlog API エラー: ステータスコード %d", resp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+func (c *Client) get(path string, params url.Values) ([]byte, error) {
+	resp, err := c.do(http.MethodGet, path, params, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+func (c *Client) post(path string, values url.Values) ([]byte, error) {
+	resp, err := c.do(http.MethodPost, path, values, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+func (c *Client) patch(path string, values url.Values) ([]byte, error) {
+	resp, err := c.do(http.MethodPatch, path, values, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,1 +1,93 @@
 package api
+
+// User represents a Backlog user.
+type User struct {
+	ID          int    `json:"id"`
+	UserID      string `json:"userId"`
+	Name        string `json:"name"`
+	MailAddress string `json:"mailAddress"`
+}
+
+// Project represents a Backlog project.
+type Project struct {
+	ID          int    `json:"id"`
+	ProjectKey  string `json:"projectKey"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// Issue represents a Backlog issue.
+type Issue struct {
+	ID          int        `json:"id"`
+	ProjectID   int        `json:"projectId"`
+	IssueKey    string     `json:"issueKey"`
+	Summary     string     `json:"summary"`
+	Description string     `json:"description"`
+	Status      *Status    `json:"status"`
+	Assignee    *User      `json:"assignee"`
+	Priority    *Priority  `json:"priority"`
+	IssueType   *IssueType `json:"issueType"`
+	DueDate     string     `json:"dueDate"`
+	StartDate   string     `json:"startDate"`
+	CreatedUser *User      `json:"createdUser"`
+	Created     string     `json:"created"`
+	Updated     string     `json:"updated"`
+	Milestone   []Milestone `json:"milestone"`
+	Category    []Category  `json:"category"`
+}
+
+// IssueType represents a Backlog issue type.
+type IssueType struct {
+	ID        int    `json:"id"`
+	ProjectID int    `json:"projectId"`
+	Name      string `json:"name"`
+	Color     string `json:"color"`
+}
+
+// Status represents a Backlog status.
+type Status struct {
+	ID        int    `json:"id"`
+	ProjectID int    `json:"projectId"`
+	Name      string `json:"name"`
+	Color     string `json:"color"`
+}
+
+// Priority represents a Backlog priority.
+type Priority struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Comment represents a Backlog comment.
+type Comment struct {
+	ID          int    `json:"id"`
+	Content     string `json:"content"`
+	CreatedUser *User  `json:"createdUser"`
+	Created     string `json:"created"`
+}
+
+// Milestone represents a Backlog milestone/version.
+type Milestone struct {
+	ID             int    `json:"id"`
+	ProjectID      int    `json:"projectId"`
+	Name           string `json:"name"`
+	ReleaseDueDate string `json:"releaseDueDate"`
+}
+
+// Category represents a Backlog category.
+type Category struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// BacklogError represents an error response from the Backlog API.
+type BacklogError struct {
+	Message  string `json:"message"`
+	Code     int    `json:"code"`
+	MoreInfo string `json:"moreInfo"`
+}
+
+// BacklogErrorResponse wraps the errors array in the API response.
+type BacklogErrorResponse struct {
+	Errors []BacklogError `json:"errors"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,1 +1,92 @@
 package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+)
+
+// Config holds the application configuration.
+type Config struct {
+	SpaceURL       string `mapstructure:"space_url"`
+	APIKey         string `mapstructure:"api_key"`
+	DefaultProject string `mapstructure:"default_project"`
+}
+
+func configDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("ホームディレクトリの取得に失敗しました: %w", err)
+	}
+	return filepath.Join(home, ".config", "bl"), nil
+}
+
+func configPath() (string, error) {
+	dir, err := configDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.yaml"), nil
+}
+
+// Load reads the config file and returns a Config.
+func Load() (*Config, error) {
+	dir, err := configDir()
+	if err != nil {
+		return nil, err
+	}
+
+	v := viper.New()
+	v.SetConfigName("config")
+	v.SetConfigType("yaml")
+	v.AddConfigPath(dir)
+
+	if err := v.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			return &Config{}, nil
+		}
+		return nil, fmt.Errorf("設定ファイルの読み込みに失敗しました: %w", err)
+	}
+
+	var cfg Config
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, fmt.Errorf("設定ファイルの解析に失敗しました: %w", err)
+	}
+	return &cfg, nil
+}
+
+// Save writes the config to the config file.
+func Save(cfg *Config) error {
+	dir, err := configDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("設定ディレクトリの作成に失敗しました: %w", err)
+	}
+
+	v := viper.New()
+	v.Set("space_url", cfg.SpaceURL)
+	v.Set("api_key", cfg.APIKey)
+	v.Set("default_project", cfg.DefaultProject)
+
+	p, err := configPath()
+	if err != nil {
+		return err
+	}
+	return v.WriteConfigAs(p)
+}
+
+// Delete removes the config file.
+func Delete() error {
+	p, err := configPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("設定ファイルの削除に失敗しました: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- `internal/config/config.go`: 設定ファイル（`~/.config/bl/config.yaml`）の Load / Save / Delete を実装
- `internal/api/types.go`: User, Project, Issue, IssueType, Status, Priority, Comment, Milestone, Category, BacklogError の型定義
- `internal/api/client.go`: HTTP クライアント（get/post/patch）、APIキー付与、エラーレスポンスのパース

## Test plan
- [x] `go build ./...` が通ること
- [x] 型定義に漏れがないこと

Closes #2