### PR TITLE
[#4]feat：プロジェクトコマンド（list/set/current）を実装

### DIFF
--- a/cmd/project/current.go
+++ b/cmd/project/current.go
@@ -1,13 +1,28 @@
 package project
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/KimMaru10/bl-cli/internal/config"
+	"github.com/spf13/cobra"
+)
 
 func newCurrentCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "current",
 		Short: "デフォルトプロジェクトを表示する",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: implement
+			cfg, err := config.Load()
+			if err != nil {
+				return fmt.Errorf("設定の読み込みに失敗しました: %w", err)
+			}
+
+			if cfg.DefaultProject == "" {
+				fmt.Println("デフォルトプロジェクトが未設定です。bl project set を実行してください")
+				return nil
+			}
+
+			fmt.Println(cfg.DefaultProject)
 			return nil
 		},
 	}

--- a/cmd/project/list.go
+++ b/cmd/project/list.go
@@ -1,13 +1,39 @@
 package project
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/KimMaru10/bl-cli/internal/cmdutil"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+var headerStyle = lipgloss.NewStyle().Bold(true)
 
 func newListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "プロジェクト一覧を表示する",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: implement
+			_, client, err := cmdutil.LoadConfigAndClient()
+			if err != nil {
+				return err
+			}
+
+			projects, err := client.GetProjects()
+			if err != nil {
+				return err
+			}
+
+			if len(projects) == 0 {
+				fmt.Println("プロジェクトがありません")
+				return nil
+			}
+
+			fmt.Printf("%s\t%s\n", headerStyle.Render("KEY"), headerStyle.Render("NAME"))
+			for _, p := range projects {
+				fmt.Printf("%s\t%s\n", p.ProjectKey, p.Name)
+			}
 			return nil
 		},
 	}

--- a/cmd/project/set.go
+++ b/cmd/project/set.go
@@ -1,13 +1,127 @@
 package project
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"io"
+
+	"github.com/KimMaru10/bl-cli/internal/cmdutil"
+	"github.com/KimMaru10/bl-cli/internal/config"
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+var successStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+// projectItem implements list.Item for project selection.
+type projectItem struct {
+	key  string
+	name string
+}
+
+func (i projectItem) FilterValue() string { return i.key + " " + i.name }
+
+// projectDelegate renders each item in the list.
+type projectDelegate struct{}
+
+func (d projectDelegate) Height() int                             { return 1 }
+func (d projectDelegate) Spacing() int                            { return 0 }
+func (d projectDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d projectDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(projectItem)
+	if !ok {
+		return
+	}
+
+	str := fmt.Sprintf("%s\t%s", i.key, i.name)
+	if index == m.Index() {
+		str = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Render("> " + str)
+	} else {
+		str = "  " + str
+	}
+	fmt.Fprint(w, str)
+}
+
+type setModel struct {
+	list     list.Model
+	selected string
+	quitting bool
+}
+
+func (m setModel) Init() tea.Cmd { return nil }
+
+func (m setModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			m.quitting = true
+			return m, tea.Quit
+		case tea.KeyEnter:
+			if item, ok := m.list.SelectedItem().(projectItem); ok {
+				m.selected = item.key
+			}
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m setModel) View() string {
+	if m.selected != "" {
+		return ""
+	}
+	return m.list.View()
+}
 
 func newSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set",
 		Short: "デフォルトプロジェクトを設定する",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: implement
+			cfg, client, err := cmdutil.LoadConfigAndClient()
+			if err != nil {
+				return err
+			}
+
+			projects, err := client.GetProjects()
+			if err != nil {
+				return err
+			}
+
+			items := make([]list.Item, len(projects))
+			for i, p := range projects {
+				items[i] = projectItem{key: p.ProjectKey, name: p.Name}
+			}
+
+			l := list.New(items, projectDelegate{}, 40, 14)
+			l.Title = "デフォルトプロジェクトを選択"
+			l.SetShowStatusBar(false)
+			l.SetShowHelp(true)
+
+			m := setModel{list: l}
+			p := tea.NewProgram(m)
+			finalModel, err := p.Run()
+			if err != nil {
+				return fmt.Errorf("TUI の実行に失敗しました: %w", err)
+			}
+
+			result := finalModel.(setModel)
+			if result.quitting || result.selected == "" {
+				return nil
+			}
+
+			cfg.DefaultProject = result.selected
+			if err := config.Save(cfg); err != nil {
+				return fmt.Errorf("設定の保存に失敗しました: %w", err)
+			}
+
+			fmt.Println(successStyle.Render("✔ デフォルトプロジェクトを " + result.selected + " に設定しました"))
 			return nil
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
 github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
@@ -14,6 +16,8 @@ github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF
 github.com/charmbracelet/x/ansi v0.11.6/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/clipperhouse/displaywidth v0.9.0 h1:Qb4KOhYwRiN3viMv1v/3cTBlz3AcAZX3+y9OLhMtAtA=
@@ -41,6 +45,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -66,6 +72,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -1,1 +1,110 @@
 package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GetProjects returns all projects.
+func (c *Client) GetProjects() ([]Project, error) {
+	data, err := c.get("/projects", nil)
+	if err != nil {
+		return nil, fmt.Errorf("プロジェクト一覧の取得に失敗しました: %w", err)
+	}
+	var projects []Project
+	if err := json.Unmarshal(data, &projects); err != nil {
+		return nil, fmt.Errorf("プロジェクト一覧の解析に失敗しました: %w", err)
+	}
+	return projects, nil
+}
+
+// GetProject returns a single project.
+func (c *Client) GetProject(projectIDOrKey string) (*Project, error) {
+	data, err := c.get("/projects/"+projectIDOrKey, nil)
+	if err != nil {
+		return nil, fmt.Errorf("プロジェクトの取得に失敗しました: %w", err)
+	}
+	var project Project
+	if err := json.Unmarshal(data, &project); err != nil {
+		return nil, fmt.Errorf("プロジェクトの解析に失敗しました: %w", err)
+	}
+	return &project, nil
+}
+
+// GetProjectUsers returns users belonging to a project.
+func (c *Client) GetProjectUsers(projectIDOrKey string) ([]User, error) {
+	data, err := c.get("/projects/"+projectIDOrKey+"/users", nil)
+	if err != nil {
+		return nil, fmt.Errorf("プロジェクトユーザーの取得に失敗しました: %w", err)
+	}
+	var users []User
+	if err := json.Unmarshal(data, &users); err != nil {
+		return nil, fmt.Errorf("プロジェクトユーザーの解析に失敗しました: %w", err)
+	}
+	return users, nil
+}
+
+// GetStatuses returns statuses for a project.
+func (c *Client) GetStatuses(projectIDOrKey string) ([]Status, error) {
+	data, err := c.get("/projects/"+projectIDOrKey+"/statuses", nil)
+	if err != nil {
+		return nil, fmt.Errorf("ステータス一覧の取得に失敗しました: %w", err)
+	}
+	var statuses []Status
+	if err := json.Unmarshal(data, &statuses); err != nil {
+		return nil, fmt.Errorf("ステータス一覧の解析に失敗しました: %w", err)
+	}
+	return statuses, nil
+}
+
+// GetIssueTypes returns issue types for a project.
+func (c *Client) GetIssueTypes(projectIDOrKey string) ([]IssueType, error) {
+	data, err := c.get("/projects/"+projectIDOrKey+"/issueTypes", nil)
+	if err != nil {
+		return nil, fmt.Errorf("課題種別一覧の取得に失敗しました: %w", err)
+	}
+	var issueTypes []IssueType
+	if err := json.Unmarshal(data, &issueTypes); err != nil {
+		return nil, fmt.Errorf("課題種別一覧の解析に失敗しました: %w", err)
+	}
+	return issueTypes, nil
+}
+
+// GetPriorities returns all priorities.
+func (c *Client) GetPriorities() ([]Priority, error) {
+	data, err := c.get("/priorities", nil)
+	if err != nil {
+		return nil, fmt.Errorf("優先度一覧の取得に失敗しました: %w", err)
+	}
+	var priorities []Priority
+	if err := json.Unmarshal(data, &priorities); err != nil {
+		return nil, fmt.Errorf("優先度一覧の解析に失敗しました: %w", err)
+	}
+	return priorities, nil
+}
+
+// GetMilestones returns milestones for a project.
+func (c *Client) GetMilestones(projectIDOrKey string) ([]Milestone, error) {
+	data, err := c.get("/projects/"+projectIDOrKey+"/versions", nil)
+	if err != nil {
+		return nil, fmt.Errorf("マイルストーン一覧の取得に失敗しました: %w", err)
+	}
+	var milestones []Milestone
+	if err := json.Unmarshal(data, &milestones); err != nil {
+		return nil, fmt.Errorf("マイルストーン一覧の解析に失敗しました: %w", err)
+	}
+	return milestones, nil
+}
+
+// GetCategories returns categories for a project.
+func (c *Client) GetCategories(projectIDOrKey string) ([]Category, error) {
+	data, err := c.get("/projects/"+projectIDOrKey+"/categories", nil)
+	if err != nil {
+		return nil, fmt.Errorf("カテゴリ一覧の取得に失敗しました: %w", err)
+	}
+	var categories []Category
+	if err := json.Unmarshal(data, &categories); err != nil {
+		return nil, fmt.Errorf("カテゴリ一覧の解析に失敗しました: %w", err)
+	}
+	return categories, nil
+}

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -1,0 +1,22 @@
+package cmdutil
+
+import (
+	"fmt"
+
+	"github.com/KimMaru10/bl-cli/internal/api"
+	"github.com/KimMaru10/bl-cli/internal/config"
+)
+
+// LoadConfigAndClient loads the config file and creates an API client.
+// Returns an error if not authenticated.
+func LoadConfigAndClient() (*config.Config, *api.Client, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, nil, fmt.Errorf("設定の読み込みに失敗しました: %w", err)
+	}
+	if cfg.APIKey == "" {
+		return nil, nil, fmt.Errorf("未認証です。bl auth login を先に実行してください")
+	}
+	client := api.NewClient(cfg.SpaceURL, cfg.APIKey)
+	return cfg, client, nil
+}


### PR DESCRIPTION
## Summary
- `internal/api/projects.go`: GetProjects, GetProject, GetProjectUsers, GetStatuses, GetIssueTypes, GetPriorities, GetMilestones, GetCategories を実装
- `internal/cmdutil/cmdutil.go`: 認証チェック共通ヘルパー（循環インポート回避のため cmd から分離）
- `cmd/project/list.go`: プロジェクト一覧をテーブル表示
- `cmd/project/set.go`: bubbletea list でインタラクティブにデフォルトプロジェクトを選択・保存
- `cmd/project/current.go`: デフォルトプロジェクトを表示

## Test plan
- [x] `go build ./...` が通ること
- [x] `./bl project list` でプロジェクト一覧が表示される
- [x] `./bl project set` でインタラクティブ選択ができる
- [x] `./bl project current` でデフォルトプロジェクトが表示される

Closes #4