### PR TITLE
[#5]feat：課題一覧コマンドとブラウザ起動ユーティリティを実装

### DIFF
--- a/cmd/issue/list.go
+++ b/cmd/issue/list.go
@@ -1,14 +1,166 @@
 package issue
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/KimMaru10/bl-cli/internal/api"
+	"github.com/KimMaru10/bl-cli/internal/browser"
+	"github.com/KimMaru10/bl-cli/internal/cmdutil"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+func statusColor(name string) lipgloss.Style {
+	switch {
+	case strings.Contains(name, "未対応"):
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("1")) // red
+	case strings.Contains(name, "処理中"):
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("4")) // blue
+	case strings.Contains(name, "処理済み"):
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("3")) // yellow
+	case strings.Contains(name, "完了"):
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("2")) // green
+	default:
+		return lipgloss.NewStyle()
+	}
+}
 
 func newListCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		assignee  string
+		status    string
+		milestone string
+		project   string
+		count     int
+		web       bool
+	)
+
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "課題一覧を表示する",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: implement
+			cfg, client, err := cmdutil.LoadConfigAndClient()
+			if err != nil {
+				return err
+			}
+
+			projectKey := project
+			if projectKey == "" {
+				projectKey = cfg.DefaultProject
+			}
+			if projectKey == "" {
+				return fmt.Errorf("プロジェクトを指定してください（--project または bl project set）")
+			}
+
+			if web {
+				url := cfg.SpaceURL + "/find/" + projectKey
+				return browser.Open(url)
+			}
+
+			proj, err := client.GetProject(projectKey)
+			if err != nil {
+				return err
+			}
+
+			opts := &api.GetIssuesOptions{
+				ProjectIDs: []int{proj.ID},
+				Count:      count,
+				Sort:       "updated",
+				Order:      "desc",
+			}
+
+			if assignee == "@me" {
+				me, err := client.GetMyself()
+				if err != nil {
+					return err
+				}
+				opts.AssigneeIDs = []int{me.ID}
+			} else if assignee != "" {
+				users, err := client.GetProjectUsers(projectKey)
+				if err != nil {
+					return err
+				}
+				for _, u := range users {
+					if u.Name == assignee {
+						opts.AssigneeIDs = []int{u.ID}
+						break
+					}
+				}
+			}
+
+			if status != "" {
+				statuses, err := client.GetStatuses(projectKey)
+				if err != nil {
+					return err
+				}
+				for _, s := range statuses {
+					if s.Name == status {
+						opts.StatusIDs = []int{s.ID}
+						break
+					}
+				}
+			}
+
+			if milestone != "" {
+				milestones, err := client.GetMilestones(projectKey)
+				if err != nil {
+					return err
+				}
+				for _, m := range milestones {
+					if m.Name == milestone {
+						opts.MilestoneIDs = []int{m.ID}
+						break
+					}
+				}
+			}
+
+			issues, err := client.GetIssues(opts)
+			if err != nil {
+				return err
+			}
+
+			if len(issues) == 0 {
+				fmt.Println("該当する課題はありません")
+				return nil
+			}
+
+			headerStyle := lipgloss.NewStyle().Bold(true)
+			fmt.Printf("%s\t%s\t%s\t%s\n",
+				headerStyle.Render("KEY"),
+				headerStyle.Render("STATUS"),
+				headerStyle.Render("ASSIGNEE"),
+				headerStyle.Render("TITLE"),
+			)
+
+			for _, issue := range issues {
+				statusName := ""
+				if issue.Status != nil {
+					statusName = statusColor(issue.Status.Name).Render(issue.Status.Name)
+				}
+
+				assigneeName := ""
+				if issue.Assignee != nil {
+					assigneeName = issue.Assignee.Name
+				}
+
+				fmt.Printf("%s\t%s\t%s\t%s\n",
+					issue.IssueKey,
+					statusName,
+					assigneeName,
+					issue.Summary,
+				)
+			}
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "担当者名（@me で自分）")
+	cmd.Flags().StringVarP(&status, "status", "s", "", "ステータス名")
+	cmd.Flags().StringVarP(&milestone, "milestone", "m", "", "マイルストーン名")
+	cmd.Flags().StringVarP(&project, "project", "p", "", "プロジェクトキー")
+	cmd.Flags().IntVarP(&count, "count", "c", 20, "表示件数")
+	cmd.Flags().BoolVarP(&web, "web", "w", false, "ブラウザで開く")
+
+	return cmd
 }

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -1,1 +1,72 @@
 package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// GetIssuesOptions holds parameters for GetIssues.
+type GetIssuesOptions struct {
+	ProjectIDs   []int
+	AssigneeIDs  []int
+	StatusIDs    []int
+	MilestoneIDs []int
+	Keyword      string
+	Count        int
+	Offset       int
+	Sort         string
+	Order        string
+}
+
+// GetIssues returns issues matching the given options.
+func (c *Client) GetIssues(opts *GetIssuesOptions) ([]Issue, error) {
+	params := url.Values{}
+
+	for _, id := range opts.ProjectIDs {
+		params.Add("projectId[]", strconv.Itoa(id))
+	}
+	for _, id := range opts.AssigneeIDs {
+		params.Add("assigneeId[]", strconv.Itoa(id))
+	}
+	for _, id := range opts.StatusIDs {
+		params.Add("statusId[]", strconv.Itoa(id))
+	}
+	for _, id := range opts.MilestoneIDs {
+		params.Add("milestoneId[]", strconv.Itoa(id))
+	}
+	if opts.Keyword != "" {
+		params.Set("keyword", opts.Keyword)
+	}
+
+	count := opts.Count
+	if count <= 0 {
+		count = 20
+	}
+	if count > 100 {
+		count = 100
+	}
+	params.Set("count", strconv.Itoa(count))
+
+	if opts.Offset > 0 {
+		params.Set("offset", strconv.Itoa(opts.Offset))
+	}
+	if opts.Sort != "" {
+		params.Set("sort", opts.Sort)
+	}
+	if opts.Order != "" {
+		params.Set("order", opts.Order)
+	}
+
+	data, err := c.get("/issues", params)
+	if err != nil {
+		return nil, fmt.Errorf("課題一覧の取得に失敗しました: %w", err)
+	}
+
+	var issues []Issue
+	if err := json.Unmarshal(data, &issues); err != nil {
+		return nil, fmt.Errorf("課題一覧の解析に失敗しました: %w", err)
+	}
+	return issues, nil
+}

--- a/internal/browser/open.go
+++ b/internal/browser/open.go
@@ -1,1 +1,21 @@
 package browser
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// Open opens the given URL in the default browser.
+func Open(url string) error {
+	var cmd string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	case "linux":
+		cmd = "xdg-open"
+	default:
+		return fmt.Errorf("ブラウザの起動に対応していないOS: %s", runtime.GOOS)
+	}
+	return exec.Command(cmd, url).Start()
+}


### PR DESCRIPTION
## Summary
- `internal/api/issues.go`: `GetIssues(opts)` メソッドを実装（フィルタ・ソート・ページング対応）
- `internal/browser/open.go`: macOS/Linux 対応のブラウザ起動ユーティリティ
- `cmd/issue/list.go`: 課題一覧コマンド
  - `--assignee/-a`, `--status/-s`, `--milestone/-m`, `--project/-p`, `--count/-c`, `--web/-w` フラグ
  - ステータスの色付け（未対応:赤, 処理中:青, 処理済み:黄, 完了:緑）
  - `--web` でブラウザ起動

## Test plan
- [x] `go build ./...` が通ること
- [x] `./bl issue list -p PROJECT` で課題一覧が表示される
- [x] `./bl issue list -a @me` で自分の課題のみ表示される
- [x] `./bl issue list -w` でブラウザが開く
- [x] 0 件の場合「該当する課題はありません」と表示される

Closes #5