### PR TITLE
[#6]feat：課題詳細コマンドとブランチ推測機能を実装

### DIFF
--- a/cmd/issue/view.go
+++ b/cmd/issue/view.go
@@ -1,14 +1,126 @@
 package issue
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/KimMaru10/bl-cli/internal/browser"
+	"github.com/KimMaru10/bl-cli/internal/cmdutil"
+	"github.com/KimMaru10/bl-cli/internal/git"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+var (
+	titleStyle   = lipgloss.NewStyle().Bold(true)
+	labelStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	urlStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("4")).Underline(true)
+)
+
+// resolveIssueKey resolves an issue key from args or the current git branch.
+func resolveIssueKey(args []string) (string, error) {
+	if len(args) > 0 {
+		return args[0], nil
+	}
+	branch, err := git.GetCurrentBranch()
+	if err != nil {
+		return "", fmt.Errorf("課題キーを指定するか、課題キーを含むブランチに切り替えてください")
+	}
+	key := git.ExtractIssueKey(branch)
+	if key == "" {
+		return "", fmt.Errorf("課題キーを指定するか、課題キーを含むブランチに切り替えてください")
+	}
+	return key, nil
+}
 
 func newViewCmd() *cobra.Command {
-	return &cobra.Command{
+	var web bool
+
+	cmd := &cobra.Command{
 		Use:   "view [issueKey]",
 		Short: "課題の詳細を表示する",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: implement
+			cfg, client, err := cmdutil.LoadConfigAndClient()
+			if err != nil {
+				return err
+			}
+
+			issueKey, err := resolveIssueKey(args)
+			if err != nil {
+				return err
+			}
+
+			if web {
+				url := cfg.SpaceURL + "/view/" + issueKey
+				return browser.Open(url)
+			}
+
+			issue, err := client.GetIssue(issueKey)
+			if err != nil {
+				return err
+			}
+
+			// Title
+			fmt.Println(titleStyle.Render(issue.IssueKey + " " + issue.Summary))
+			fmt.Println()
+
+			// Status | Priority | IssueType
+			var meta []string
+			if issue.Status != nil {
+				meta = append(meta, statusColor(issue.Status.Name).Render(issue.Status.Name))
+			}
+			if issue.Priority != nil {
+				meta = append(meta, issue.Priority.Name)
+			}
+			if issue.IssueType != nil {
+				meta = append(meta, issue.IssueType.Name)
+			}
+			if len(meta) > 0 {
+				fmt.Println(strings.Join(meta, " | "))
+			}
+
+			// Assignee | CreatedUser
+			var people []string
+			if issue.Assignee != nil {
+				people = append(people, labelStyle.Render("担当者: ")+issue.Assignee.Name)
+			}
+			if issue.CreatedUser != nil {
+				people = append(people, labelStyle.Render("作成者: ")+issue.CreatedUser.Name)
+			}
+			if len(people) > 0 {
+				fmt.Println(strings.Join(people, " | "))
+			}
+
+			// Due date
+			if issue.DueDate != "" {
+				fmt.Println(labelStyle.Render("期日: ") + issue.DueDate)
+			}
+
+			// Milestones
+			if len(issue.Milestone) > 0 {
+				var names []string
+				for _, m := range issue.Milestone {
+					names = append(names, m.Name)
+				}
+				fmt.Println(labelStyle.Render("マイルストーン: ") + strings.Join(names, ", "))
+			}
+
+			// Description
+			if issue.Description != "" {
+				fmt.Println()
+				fmt.Println(issue.Description)
+			}
+
+			// URL
+			fmt.Println()
+			fmt.Println(labelStyle.Render("URL: ") + urlStyle.Render(cfg.SpaceURL+"/view/"+issue.IssueKey))
+
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&web, "web", "w", false, "ブラウザで開く")
+
+	return cmd
 }

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -70,3 +70,16 @@ func (c *Client) GetIssues(opts *GetIssuesOptions) ([]Issue, error) {
 	}
 	return issues, nil
 }
+
+// GetIssue returns a single issue by key or ID.
+func (c *Client) GetIssue(issueIDOrKey string) (*Issue, error) {
+	data, err := c.get("/issues/"+issueIDOrKey, nil)
+	if err != nil {
+		return nil, fmt.Errorf("課題の取得に失敗しました: %w", err)
+	}
+	var issue Issue
+	if err := json.Unmarshal(data, &issue); err != nil {
+		return nil, fmt.Errorf("課題の解析に失敗しました: %w", err)
+	}
+	return &issue, nil
+}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -1,1 +1,25 @@
 package git
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var issueKeyPattern = regexp.MustCompile(`[A-Z][A-Z0-9]+-\d+`)
+
+// GetCurrentBranch returns the current git branch name.
+func GetCurrentBranch() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ExtractIssueKey extracts a Backlog issue key from a branch name.
+// Returns an empty string if no match is found.
+func ExtractIssueKey(branch string) string {
+	match := issueKeyPattern.FindString(branch)
+	return match
+}


### PR DESCRIPTION
## Summary
- `internal/git/branch.go`: `GetCurrentBranch()`, `ExtractIssueKey()` を実装（ブランチ名から課題キー抽出）
- `internal/api/issues.go`: `GetIssue()` メソッドを追加
- `cmd/issue/view.go`: 課題詳細表示コマンド
  - 引数省略時にブランチ名から課題キーを推測
  - `--web/-w` でブラウザ起動
  - lipgloss でタイトル・ステータス・ラベル・URLを整形

## Test plan
- [x] `go build ./...` が通ること
- [x] `./bl issue view PROJ-123` で課題詳細が表示される
- [x] 課題キー含むブランチ上で `./bl issue view` が動作する
- [x] `./bl issue view -w PROJ-123` でブラウザが開く

Closes #6