### PR TITLE
[#7]feat：課題作成コマンドとTUIコンポーネントを実装

### DIFF
--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -1,14 +1,212 @@
 package issue
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/KimMaru10/bl-cli/internal/api"
+	"github.com/KimMaru10/bl-cli/internal/cmdutil"
+	"github.com/KimMaru10/bl-cli/internal/tui"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+var successStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
 
 func newCreateCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		summary     string
+		typeName    string
+		priority    string
+		assignee    string
+		description string
+		dueDate     string
+		milestone   string
+		project     string
+	)
+
+	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "課題を作成する",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: implement
+			cfg, client, err := cmdutil.LoadConfigAndClient()
+			if err != nil {
+				return err
+			}
+
+			projectKey := project
+			if projectKey == "" {
+				projectKey = cfg.DefaultProject
+			}
+			if projectKey == "" {
+				return fmt.Errorf("プロジェクトを指定してください（--project または bl project set）")
+			}
+
+			proj, err := client.GetProject(projectKey)
+			if err != nil {
+				return err
+			}
+
+			opts := &api.CreateIssueOptions{
+				ProjectID: proj.ID,
+			}
+
+			if summary != "" {
+				// Flag mode
+				if typeName == "" || priority == "" {
+					return fmt.Errorf("--type と --priority は必須です")
+				}
+
+				opts.Summary = summary
+				opts.Description = description
+				opts.DueDate = dueDate
+
+				issueTypes, err := client.GetIssueTypes(projectKey)
+				if err != nil {
+					return err
+				}
+				for _, t := range issueTypes {
+					if t.Name == typeName {
+						opts.IssueTypeID = t.ID
+						break
+					}
+				}
+				if opts.IssueTypeID == 0 {
+					return fmt.Errorf("課題種別 '%s' が見つかりません", typeName)
+				}
+
+				priorities, err := client.GetPriorities()
+				if err != nil {
+					return err
+				}
+				for _, p := range priorities {
+					if p.Name == priority {
+						opts.PriorityID = p.ID
+						break
+					}
+				}
+				if opts.PriorityID == 0 {
+					return fmt.Errorf("優先度 '%s' が見つかりません", priority)
+				}
+
+				if assignee != "" {
+					users, err := client.GetProjectUsers(projectKey)
+					if err != nil {
+						return err
+					}
+					for _, u := range users {
+						if u.Name == assignee {
+							opts.AssigneeID = u.ID
+							break
+						}
+					}
+				}
+
+				if milestone != "" {
+					milestones, err := client.GetMilestones(projectKey)
+					if err != nil {
+						return err
+					}
+					for _, m := range milestones {
+						if m.Name == milestone {
+							opts.MilestoneIDs = []int{m.ID}
+							break
+						}
+					}
+				}
+			} else {
+				// Interactive mode
+				s, ok := tui.Input("タイトル: ", "課題のタイトルを入力")
+				if !ok || s == "" {
+					return nil
+				}
+				opts.Summary = s
+
+				// Issue type
+				issueTypes, err := client.GetIssueTypes(projectKey)
+				if err != nil {
+					return err
+				}
+				typeItems := make([]tui.SelectItem, len(issueTypes))
+				for i, t := range issueTypes {
+					typeItems[i] = tui.SelectItem{ID: t.ID, Label: t.Name}
+				}
+				selected := tui.Select("課題種別を選択", typeItems)
+				if selected == nil {
+					return nil
+				}
+				opts.IssueTypeID = selected.ID
+
+				// Priority
+				priorities, err := client.GetPriorities()
+				if err != nil {
+					return err
+				}
+				prioItems := make([]tui.SelectItem, len(priorities))
+				for i, p := range priorities {
+					prioItems[i] = tui.SelectItem{ID: p.ID, Label: p.Name}
+				}
+				selected = tui.Select("優先度を選択", prioItems)
+				if selected == nil {
+					return nil
+				}
+				opts.PriorityID = selected.ID
+
+				// Assignee
+				users, err := client.GetProjectUsers(projectKey)
+				if err != nil {
+					return err
+				}
+				userItems := []tui.SelectItem{{ID: 0, Label: "未設定"}}
+				for _, u := range users {
+					userItems = append(userItems, tui.SelectItem{ID: u.ID, Label: u.Name})
+				}
+				selected = tui.Select("担当者を選択", userItems)
+				if selected == nil {
+					return nil
+				}
+				if selected.ID > 0 {
+					opts.AssigneeID = selected.ID
+				}
+
+				// Due date
+				d, ok := tui.Input("期日 (yyyy-MM-dd, 空欄で省略): ", "2025-12-31")
+				if !ok {
+					return nil
+				}
+				opts.DueDate = d
+
+				// Description
+				desc, ok := tui.Input("説明 (空欄で省略): ", "")
+				if !ok {
+					return nil
+				}
+				opts.Description = desc
+
+				// Confirm
+				if !tui.Confirm("この内容で課題を作成しますか？") {
+					fmt.Println("キャンセルしました")
+					return nil
+				}
+			}
+
+			issue, err := client.CreateIssue(opts)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(successStyle.Render("✔ " + issue.IssueKey + " を作成しました"))
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&summary, "summary", "s", "", "タイトル")
+	cmd.Flags().StringVarP(&typeName, "type", "t", "", "課題種別名")
+	cmd.Flags().StringVar(&priority, "priority", "", "優先度名")
+	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "担当者名")
+	cmd.Flags().StringVarP(&description, "description", "d", "", "説明")
+	cmd.Flags().StringVar(&dueDate, "due-date", "", "期日（yyyy-MM-dd）")
+	cmd.Flags().StringVarP(&milestone, "milestone", "m", "", "マイルストーン名")
+	cmd.Flags().StringVarP(&project, "project", "p", "", "プロジェクトキー")
+
+	return cmd
 }

--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -83,3 +83,55 @@ func (c *Client) GetIssue(issueIDOrKey string) (*Issue, error) {
 	}
 	return &issue, nil
 }
+
+// CreateIssueOptions holds parameters for CreateIssue.
+type CreateIssueOptions struct {
+	ProjectID   int
+	Summary     string
+	IssueTypeID int
+	PriorityID  int
+	Description string
+	AssigneeID  int
+	DueDate     string
+	StartDate   string
+	MilestoneIDs []int
+	CategoryIDs  []int
+}
+
+// CreateIssue creates a new issue.
+func (c *Client) CreateIssue(opts *CreateIssueOptions) (*Issue, error) {
+	params := url.Values{}
+	params.Set("projectId", strconv.Itoa(opts.ProjectID))
+	params.Set("summary", opts.Summary)
+	params.Set("issueTypeId", strconv.Itoa(opts.IssueTypeID))
+	params.Set("priorityId", strconv.Itoa(opts.PriorityID))
+
+	if opts.Description != "" {
+		params.Set("description", opts.Description)
+	}
+	if opts.AssigneeID > 0 {
+		params.Set("assigneeId", strconv.Itoa(opts.AssigneeID))
+	}
+	if opts.DueDate != "" {
+		params.Set("dueDate", opts.DueDate)
+	}
+	if opts.StartDate != "" {
+		params.Set("startDate", opts.StartDate)
+	}
+	for _, id := range opts.MilestoneIDs {
+		params.Add("milestoneId[]", strconv.Itoa(id))
+	}
+	for _, id := range opts.CategoryIDs {
+		params.Add("categoryId[]", strconv.Itoa(id))
+	}
+
+	data, err := c.post("/issues", params)
+	if err != nil {
+		return nil, fmt.Errorf("課題の作成に失敗しました: %w", err)
+	}
+	var issue Issue
+	if err := json.Unmarshal(data, &issue); err != nil {
+		return nil, fmt.Errorf("課題の解析に失敗しました: %w", err)
+	}
+	return &issue, nil
+}

--- a/internal/tui/confirm.go
+++ b/internal/tui/confirm.go
@@ -1,1 +1,53 @@
 package tui
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type confirmModel struct {
+	message  string
+	confirmed bool
+	done     bool
+}
+
+func (m confirmModel) Init() tea.Cmd { return nil }
+
+func (m confirmModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "y", "Y":
+			m.confirmed = true
+			m.done = true
+			return m, tea.Quit
+		case "n", "N", "q", "ctrl+c", "esc":
+			m.confirmed = false
+			m.done = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m confirmModel) View() string {
+	if m.done {
+		return ""
+	}
+	prompt := lipgloss.NewStyle().Bold(true).Render(m.message)
+	return fmt.Sprintf("%s [y/N] ", prompt)
+}
+
+// Confirm shows a yes/no confirmation prompt.
+// Returns true if the user confirmed.
+func Confirm(message string) bool {
+	m := confirmModel{message: message}
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return false
+	}
+	return finalModel.(confirmModel).confirmed
+}

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -1,1 +1,58 @@
 package tui
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type inputModel struct {
+	input    textinput.Model
+	value    string
+	quitting bool
+}
+
+func (m inputModel) Init() tea.Cmd { return textinput.Blink }
+
+func (m inputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			m.quitting = true
+			return m, tea.Quit
+		case tea.KeyEnter:
+			m.value = m.input.Value()
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return m, cmd
+}
+
+func (m inputModel) View() string {
+	return m.input.View()
+}
+
+// Input shows a text input prompt and returns the entered value.
+// Returns empty string and false if the user cancelled.
+func Input(prompt, placeholder string) (string, bool) {
+	ti := textinput.New()
+	ti.Prompt = prompt
+	ti.Placeholder = placeholder
+	ti.Focus()
+	ti.Width = 50
+
+	m := inputModel{input: ti}
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return "", false
+	}
+
+	result := finalModel.(inputModel)
+	if result.quitting {
+		return "", false
+	}
+	return result.value, true
+}

--- a/internal/tui/selector.go
+++ b/internal/tui/selector.go
@@ -1,1 +1,97 @@
 package tui
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// SelectItem represents a selectable item with an ID and label.
+type SelectItem struct {
+	ID    int
+	Label string
+}
+
+func (i SelectItem) FilterValue() string { return i.Label }
+
+type selectDelegate struct{}
+
+func (d selectDelegate) Height() int                             { return 1 }
+func (d selectDelegate) Spacing() int                            { return 0 }
+func (d selectDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d selectDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(SelectItem)
+	if !ok {
+		return
+	}
+	if index == m.Index() {
+		fmt.Fprint(w, lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Render("> "+i.Label))
+	} else {
+		fmt.Fprint(w, "  "+i.Label)
+	}
+}
+
+type selectModel struct {
+	list     list.Model
+	selected *SelectItem
+	quitting bool
+}
+
+func (m selectModel) Init() tea.Cmd { return nil }
+
+func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			m.quitting = true
+			return m, tea.Quit
+		case tea.KeyEnter:
+			if item, ok := m.list.SelectedItem().(SelectItem); ok {
+				m.selected = &item
+			}
+			return m, tea.Quit
+		}
+	}
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m selectModel) View() string {
+	if m.selected != nil {
+		return ""
+	}
+	return m.list.View()
+}
+
+// Select shows an interactive list and returns the selected item.
+// Returns nil if the user cancelled.
+func Select(title string, items []SelectItem) *SelectItem {
+	listItems := make([]list.Item, len(items))
+	for i, item := range items {
+		listItems[i] = item
+	}
+
+	l := list.New(listItems, selectDelegate{}, 50, min(len(items)+6, 20))
+	l.Title = title
+	l.SetShowStatusBar(false)
+	l.SetShowHelp(true)
+
+	m := selectModel{list: l}
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return nil
+	}
+
+	result := finalModel.(selectModel)
+	if result.quitting || result.selected == nil {
+		return nil
+	}
+	return result.selected
+}


### PR DESCRIPTION
## Summary
- `internal/api/issues.go`: `CreateIssue(opts)` メソッドを追加
- `internal/tui/selector.go`: フィルタリング付きリスト選択コンポーネント
- `internal/tui/input.go`: テキスト入力コンポーネント
- `internal/tui/confirm.go`: Yes/No 確認プロンプト
- `cmd/issue/create.go`: 課題作成コマンド
  - フラグ指定モード: `--summary`, `--type`, `--priority` 等
  - インタラクティブモード: TUI で順番に入力・選択

## Test plan
- [x] `go build ./...` が通ること
- [x] `./bl issue create -s "テスト" -t "タスク" --priority "中" -p PROJECT` でフラグ指定作成
- [x] `./bl issue create` でインタラクティブモードが動作する
- [x] 確認プロンプトで N を押すとキャンセルされる

Closes #7