### PR TITLE
[#10] GoReleaser + Homebrew 配布設定

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,38 @@
+version: 2
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    binary: bl
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - format_overrides:
+      - goos: darwin
+        format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+brews:
+  - repository:
+      owner: KimMaru10
+      name: homebrew-bl-cli
+    name: bl-cli
+    homepage: https://github.com/KimMaru10/bl-cli
+    description: "Backlog CLI - ターミナルから Backlog を操作"
+    install: |
+      bin.install "bl"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean
+.PHONY: build install clean release-dry-run release
 
 build:
 	go build -o bl .
@@ -8,3 +8,9 @@ install:
 
 clean:
 	rm -f bl
+
+release-dry-run:
+	goreleaser release --snapshot --clean
+
+release:
+	goreleaser release --clean

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,11 @@ func init() {
 	rootCmd.AddCommand(issue.NewIssueCmd())
 }
 
+// SetVersion sets the version string shown by --version.
+func SetVersion(v string) {
+	rootCmd.Version = v
+}
+
 // Execute runs the root command.
 func Execute() error {
 	return rootCmd.Execute()

--- a/main.go
+++ b/main.go
@@ -6,7 +6,10 @@ import (
 	"github.com/KimMaru10/bl-cli/cmd"
 )
 
+var version = "dev"
+
 func main() {
+	cmd.SetVersion(version)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Summary
- `.goreleaser.yaml`: GoReleaser v2 設定（darwin/linux × amd64/arm64、ldflags でバージョン埋め込み、Homebrew tap 設定）
- `.github/workflows/release.yml`: タグプッシュ（v*）トリガーでリリースを自動実行
- `main.go`: `version` 変数を追加し `cmd.SetVersion()` で渡す
- `cmd/root.go`: `SetVersion()` 関数を追加、`--version` フラグが有効に
- `Makefile`: `release-dry-run` / `release` ターゲットを追加

## リリース手順
```bash
git tag v0.1.0
git push origin v0.1.0
```
GitHub Actions が自動で GoReleaser を実行し、バイナリとHomebrew formulaが生成されます。

## Test plan
- [x] `go build` が通ること
- [x] `./bl --version` で `bl version dev` と表示されること
- [ ] `make release-dry-run` でスナップショットリリースが成功すること（goreleaser インストール後）