### PR TITLE
[#27] 課題作成・編集にマイルストーンと開始日設定を追加

### DIFF
--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -19,6 +19,7 @@ func newCreateCmd() *cobra.Command {
 		priority    string
 		assignee    string
 		description string
+		startDate   string
 		dueDate     string
 		milestone   string
 		project     string
@@ -60,6 +61,7 @@ func newCreateCmd() *cobra.Command {
 
 				opts.Summary = summary
 				opts.Description = description
+				opts.StartDate = startDate
 				opts.DueDate = dueDate
 
 				issueTypes, err := client.GetIssueTypes(projectKey)
@@ -170,8 +172,32 @@ func newCreateCmd() *cobra.Command {
 					opts.AssigneeID = selected.ID
 				}
 
+				// Milestone
+				milestones, err := client.GetMilestones(projectKey)
+				if err != nil {
+					return err
+				}
+				msItems := []tui.SelectItem{{ID: 0, Label: "未設定"}}
+				for _, m := range milestones {
+					msItems = append(msItems, tui.SelectItem{ID: m.ID, Label: m.Name})
+				}
+				selected = tui.Select("マイルストーンを選択", msItems)
+				if selected == nil {
+					return nil
+				}
+				if selected.ID > 0 {
+					opts.MilestoneIDs = []int{selected.ID}
+				}
+
+				// Start date
+				sd, ok := tui.Input("開始日 (空欄で省略): ", "yyyy-MM-dd")
+				if !ok {
+					return nil
+				}
+				opts.StartDate = sd
+
 				// Due date
-				d, ok := tui.Input("期日 (yyyy-MM-dd, 空欄で省略): ", "2025-12-31")
+				d, ok := tui.Input("期日 (空欄で省略): ", "yyyy-MM-dd")
 				if !ok {
 					return nil
 				}
@@ -206,6 +232,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&priority, "priority", "", "優先度名")
 	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "担当者名")
 	cmd.Flags().StringVarP(&description, "description", "d", "", "説明")
+	cmd.Flags().StringVar(&startDate, "start-date", "", "開始日（yyyy-MM-dd）")
 	cmd.Flags().StringVar(&dueDate, "due-date", "", "期日（yyyy-MM-dd）")
 	cmd.Flags().StringVarP(&milestone, "milestone", "m", "", "マイルストーン名")
 	cmd.Flags().StringVarP(&project, "project", "p", "", "プロジェクトキー")

--- a/cmd/issue/edit.go
+++ b/cmd/issue/edit.go
@@ -17,6 +17,7 @@ func newEditCmd() *cobra.Command {
 	var (
 		status    string
 		assignee  string
+		startDate string
 		dueDate   string
 		priority  string
 		milestone string
@@ -49,8 +50,9 @@ func newEditCmd() *cobra.Command {
 			_ = cfg
 
 			hasFlags := cmd.Flags().Changed("status") || cmd.Flags().Changed("assignee") ||
-				cmd.Flags().Changed("due-date") || cmd.Flags().Changed("priority") ||
-				cmd.Flags().Changed("milestone") || cmd.Flags().Changed("comment")
+				cmd.Flags().Changed("start-date") || cmd.Flags().Changed("due-date") ||
+				cmd.Flags().Changed("priority") || cmd.Flags().Changed("milestone") ||
+				cmd.Flags().Changed("comment")
 
 			opts := &api.UpdateIssueOptions{}
 
@@ -83,6 +85,10 @@ func newEditCmd() *cobra.Command {
 							break
 						}
 					}
+				}
+
+				if startDate != "" {
+					opts.StartDate = strPtr(startDate)
 				}
 
 				if dueDate != "" {
@@ -129,6 +135,7 @@ func newEditCmd() *cobra.Command {
 					{ID: 3, Label: "期日を変更"},
 					{ID: 4, Label: "優先度を変更"},
 					{ID: 5, Label: "マイルストーンを変更"},
+					{ID: 6, Label: "開始日を変更"},
 				}
 
 				selected := tui.Select("編集項目を選択", editItems)
@@ -223,6 +230,16 @@ func newEditCmd() *cobra.Command {
 					} else {
 						opts.MilestoneIDs = []int{}
 					}
+
+				case 6: // Start date
+					current := currentIssue.StartDate
+					val, ok := tui.Input(fmt.Sprintf("開始日 (現在: %s): ", current), "yyyy-MM-dd")
+					if !ok {
+						return nil
+					}
+					if val != "" {
+						opts.StartDate = strPtr(val)
+					}
 				}
 
 				if !tui.Confirm("この内容で更新しますか？") {
@@ -243,6 +260,7 @@ func newEditCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&status, "status", "", "ステータス名")
 	cmd.Flags().StringVarP(&assignee, "assignee", "a", "", "担当者名")
+	cmd.Flags().StringVar(&startDate, "start-date", "", "開始日（yyyy-MM-dd）")
 	cmd.Flags().StringVar(&dueDate, "due-date", "", "期日（yyyy-MM-dd）")
 	cmd.Flags().StringVar(&priority, "priority", "", "優先度名")
 	cmd.Flags().StringVarP(&milestone, "milestone", "m", "", "マイルストーン名")


### PR DESCRIPTION
## Summary
- `bl issue create` / `bl issue edit` でマイルストーンと開始日 (`startDate`) を CLI から指定可能にする
- API 層は既に対応済みで、CLI 側に Flag・Interactive 両モードで項目が欠落していたため補完
- 空欄入力時は opts.StartDate を未設定のままにし、API への空文字送信を回避

Closes #27

## 変更内容

### \`cmd/issue/create.go\`
- Flag モード: \`--start-date\` フラグを追加し \`opts.StartDate\` に渡す
- Interactive モード:
  - マイルストーン選択 (未設定 + プロジェクトのマイルストーン一覧から単一選択)
  - 開始日入力 (\`yyyy-MM-dd\`、空欄可)
- 期日・開始日のプレースホルダーを \`yyyy-MM-dd\` に統一 (edit.go と一致)

### \`cmd/issue/edit.go\`
- Flag モード: \`--start-date\` フラグを追加し \`opts.StartDate\` に渡す (空文字はガード)
- Interactive モードに「開始日を変更」項目 (ID:6) を追加。空欄入力時は変更しない

## Test plan
- [x] \`go build ./...\` 成功
- [x] \`go vet ./...\` パス
- [ ] \`bl issue create --start-date 2026-06-01\` で開始日が反映される
- [ ] \`bl issue create\` (Interactive) でマイルストーン選択と開始日入力ができる
- [ ] \`bl issue edit XXX-1 --start-date 2026-06-01\` で開始日が更新される
- [ ] \`bl issue edit XXX-1\` (Interactive) で「開始日を変更」を選択して更新できる

## 補足
code-reviewer の指摘事項のうち、編集項目の並び順変更 (期日→開始日の時系列化) は既存 ID 依存への影響を考慮し本 PR ではスコープ外とした。`edit.go` の \`case 3 (DueDate)\` も空欄入力で空文字送信される既存バグが残っているが、本 PR 範囲外。